### PR TITLE
basePath is not mandatory now and op scope composing will work without tags

### DIFF
--- a/pyswagger/scanner/type_reducer.py
+++ b/pyswagger/scanner/type_reducer.py
@@ -17,8 +17,8 @@ class TypeReduce(object):
         scope = obj.tags[0] if obj.tags and len(obj.tags) > 0 else None
         name = obj.operationId if obj.operationId else None
 
-        if scope and name:
-            new_scope = scope_compose(scope, name)
+        new_scope = scope_compose(scope, name)
+        if new_scope:
             if new_scope in self.op.keys():
                 raise ValueError('duplicated key found: ' + new_scope)
 

--- a/pyswagger/scanner/v2_0/patch_obj.py
+++ b/pyswagger/scanner/v2_0/patch_obj.py
@@ -37,7 +37,7 @@ class PatchObject(object):
     def _path_item(self, path, obj, app):
         """
         """
-        url = app.root.host + app.root.basePath + jp_split(path)[-1]
+        url = app.root.host + (app.root.basePath or '') + jp_split(path)[-1]
         for c in PathItemContext.__swagger_child__:
             o = getattr(obj, c[0])
             if isinstance(o, Operation):


### PR DESCRIPTION
This pull request aimed to solve 2 issues:

(1) when basePath  is not provided (it is not mandatory according to swagger v2 spec) there is an exception

``` python
/pyswagger/scanner/v2_0/patch_obj.py in _path_item(self, path, obj, app)
     38         """
     39         """
---> 40         url = app.root.host + app.root.basePath + jp_split(path)[-1]
     41         for c in PathItemContext.__swagger_child__:
     42             o = getattr(obj, c[0])

TypeError: coercing to Unicode: need string or buffer, NoneType found
```

(2) app.op is not populating if there are no tags in the path
