### PR TITLE
If _format is not in primitive map, return the mapping for None.

### DIFF
--- a/pyswagger/primitives/__init__.py
+++ b/pyswagger/primitives/__init__.py
@@ -90,7 +90,11 @@ class Primitive(object):
 
     def get(self, _type, _format=None):
         r = self._map.get(_type, None)
-        return (None, None) if r == None else r.get(_format, (None, None))
+        if r is None:
+            return (None, None)
+        if _format in r:
+            return r.get(_format)
+        return r.get(None)
 
     def register(self, _type, _format, creater, _2nd_pass=None):
         """ register a type/format handler when producing primitives

--- a/pyswagger/primitives/_model.py
+++ b/pyswagger/primitives/_model.py
@@ -15,7 +15,7 @@ class Model(dict):
         super(Model, self).__init__()
 
     def apply_with(self, obj, val, ctx):
-        """ recursivly apply Schema object
+        """ recursively apply Schema object
 
         :param obj.Model obj: model object to instruct how to create this model
         :param dict val: things used to construct this model

--- a/pyswagger/primitives/_str.py
+++ b/pyswagger/primitives/_str.py
@@ -10,7 +10,7 @@ def validate_str(obj, ret, val, ctx):
     if obj.maxLength and len(ret) > obj.maxLength:
         raise ValidationError('[{0}] is longer than {1} characters'.format(ret, str(obj.maxLength)))
     if obj.minLength and len(ret) < obj.minLength:
-        raise ValidationError('[{0}] is shoter than {1} characters'.format(ret, str(obj.minLength)))
+        raise ValidationError('[{0}] is shorter than {1} characters'.format(ret, str(obj.minLength)))
 
     # TODO: handle pattern
     return val


### PR DESCRIPTION
The OpenAPI specifications state that

> the format property is an open string-valued property, and can have any value to support documentation needs

Currently if the _format given is not in the primitive mapping the mapping
returns (None, None) and an error is thrown. A better behavior would be to
default to the `None` mapping for unknown formats.