### PR TITLE
Make headers could be queried in case-insensitive way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
         
 python:
     - "2.7"
-    - "3.3"
+    - "3.4"
     - "3.5"
     - "3.6"
 install:

--- a/pyswagger/io.py
+++ b/pyswagger/io.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from .primitives.comm import PrimJSONEncoder
-from .utils import final, deref
+from .utils import final, deref, CaseInsensitiveDict
 from pyswagger import errs
 from uuid import uuid4
 import six
@@ -33,7 +33,7 @@ class Request(object):
         self.__p = params
         self.__url = self.__op.url
         self.__path = self.__op.path
-        self.__header = {}
+        self.__header = CaseInsensitiveDict()
 
         self.__consume = None
         self.__produce = None
@@ -42,7 +42,7 @@ class Request(object):
     def reset(self):
         self.__url = self.__op.url
         self.__path = self.__op.path
-        self.__header = {}
+        self.__header = CaseInsensitiveDict()
         self.__data = None
 
     def consume(self, consume):
@@ -350,7 +350,7 @@ class Response(object):
 
         # init properties
         self.__status = None
-        self.__header = {}
+        self.__header = CaseInsensitiveDict()
 
         # options
         self.__raw_body_only = False

--- a/pyswagger/tests/test_utils.py
+++ b/pyswagger/tests/test_utils.py
@@ -429,3 +429,28 @@ class WalkTestCase(unittest.TestCase):
             [2, 3, 5, 4, 2],
             [2, 3 ,4, 2]
             ]))
+
+    def test_case_insensitive_dict(self):
+        """ test utils.CaseInsensitiveDict
+        """
+        normal = utils.CaseInsensitiveDict()
+        normal['Content-Type'] = 'application/json'
+        self.assertTrue('Content-Type' in normal)
+        self.assertTrue('content-type' in normal)
+        self.assertEqual(normal['content-type'], 'application/json')
+
+        # test iteration
+        for k, v in normal.iteritems():
+            self.assertEqual(k, 'Content-Type')
+            self.assertEqual(v, 'application/json')
+            break
+        else:
+            # should not reach here
+            self.assertTrue(False)
+
+        for v in normal.itervalues():
+            self.assertEqual(v, 'application/json')
+            break
+        else:
+            # should not reach here
+            self.assertTrue(False)

--- a/pyswagger/utils.py
+++ b/pyswagger/utils.py
@@ -9,6 +9,7 @@ import re
 import os
 import operator
 import functools
+import collections
 
 #TODO: accept varg
 def scope_compose(scope, name, sep=private.SCOPE_SEPARATOR):
@@ -593,3 +594,45 @@ def patch_path(base_path, path):
         path = path[1:]
 
     return path
+
+
+class CaseInsensitiveDict(collections.MutableMapping):
+    """ a case insensitive dict:
+        - allow to query with case insensitive keys (get, in)
+        - iteration would return original key
+
+    A reference implementation could be found in
+
+        https://github.com/requests/
+    """
+
+    def __init__(self):
+        self._store = dict()
+
+    def __setitem__(self, key, value):
+        self._store[key.lower()] = (key, value)
+
+    def __getitem__(self, key):
+        return self._store[key.lower()][1]
+
+    def __delitem__(self, key):
+        del self._store[key.lower()]
+
+    def __iter__(self):
+        return (original_key for original_key, _ in six.itervalues(self._store))
+
+    def iteritems(self):
+        return six.itervalues(self._store)
+
+    def itervalues(self):
+        return (value for _, value in six.itervalues(self._store))
+
+    def __in__(self, key):
+        return key.lower() in self._store
+
+    def __len__(self):
+        return len(self._store)
+
+    def __repr__(self):
+        return str(dict(self.items()))
+


### PR DESCRIPTION
Refer to this issue:
    https://github.com/pyopenapi/pyswagger/issues/156

A reference implementation for a case insensitive mapping is based on
    https://github.com/requests/requests/blob/master/requests/structures.py#L15