### PR TITLE
add .idea folder to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # vim
 *.swp
+
+# Jetbrains metadata
+.idea/


### PR DESCRIPTION
.idea folder contains JetBrains metadata. When programming exclusively
with Python, this folder should be added to the .gitignore to prevent
confusion in the IDE.