### PR TITLE
Update configuration parameter for basicAuth

### DIFF
--- a/docs/rst/index.rst
+++ b/docs/rst/index.rst
@@ -38,7 +38,7 @@ Getting Started
 
         # init Security for authorization
         auth = Security(app)
-        auth.update_with('simple_basic_auth', ('user', 'password')) # basic auth
+        auth.update_with('basicAuth', ('user', 'password')) # basic auth
         auth.update_with('simple_api_key', '12312312312312312313q') # api key
         auth.update_with('simple_oauth2', '12334546556521123fsfss') # oauth2
 

--- a/docs/rst/topics/main.rst
+++ b/docs/rst/topics/main.rst
@@ -31,7 +31,7 @@ Security is a placeholder of authorizations,
     auth = Security(app)
 
     # insert autorization information
-    app.update_with('simple_basicAuth', ('user', 'password'))
+    app.update_with('basicAuth', ('user', 'password'))
     app.update_with('simple_apiKey', 'token123')
     app.update_with('simple_oath2', 'token123456')
 


### PR DESCRIPTION
The current documentation states to use the parameter "simple_basic_auth" or "simple_basicAuth" with pyswagger's Auth class. Unfortunately, this fails with version 0.8.39.
I corrected the documentation accordingly.

Please let me know if you have any comments to this patch.