### PR TITLE
Change to support python 3.10

### DIFF
--- a/pyswagger/io.py
+++ b/pyswagger/io.py
@@ -388,7 +388,7 @@ class Response(object):
              final(self.__op.responses.get('default', None)))
 
         if header != None:
-            if isinstance(header, (collections.Mapping, collections.MutableMapping)):
+            if isinstance(header, (collections.abc.Mapping, collections.abc.MutableMapping)):
                 for k, v in six.iteritems(header):
                     self._convert_header(r, k, v)
             else:


### PR DESCRIPTION
The `Mapping` and `MutableMapping` classes have moved from `collections` to `collections.abc`.

https://docs.python.org/3.10/library/collections.abc.html

This will allow running for Python 3.10