### PR TITLE
fix MutableMapping import for Python 3.3+

### DIFF
--- a/pyswagger/compat.py
+++ b/pyswagger/compat.py
@@ -1,0 +1,7 @@
+"""Compatability."""
+
+try:
+    from collections import MutableMapping
+except ImportError:
+    # Python 3.3+
+    from collections.abc import MutableMapping

--- a/pyswagger/io.py
+++ b/pyswagger/io.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .compat import MutableMapping
 from .primitives.comm import PrimJSONEncoder
 from .utils import final, deref, CaseInsensitiveDict
 from pyswagger import errs
@@ -388,7 +389,7 @@ class Response(object):
              final(self.__op.responses.get('default', None)))
 
         if header != None:
-            if isinstance(header, (collections.Mapping, collections.MutableMapping)):
+            if isinstance(header, (collections.Mapping, MutableMapping)):
                 for k, v in six.iteritems(header):
                     self._convert_header(r, k, v)
             else:

--- a/pyswagger/utils.py
+++ b/pyswagger/utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .compat import MutableMapping
 from .consts import private
 from .errs import CycleDetectionError
 import six
@@ -9,7 +10,6 @@ import re
 import os
 import operator
 import functools
-import collections
 
 #TODO: accept varg
 def scope_compose(scope, name, sep=private.SCOPE_SEPARATOR):
@@ -596,7 +596,7 @@ def patch_path(base_path, path):
     return path
 
 
-class CaseInsensitiveDict(collections.MutableMapping):
+class CaseInsensitiveDict(MutableMapping):
     """ a case insensitive dict:
         - allow to query with case insensitive keys (get, in)
         - iteration would return original key


### PR DESCRIPTION
In Python 3.3 collections.MutableMapping was moved to collections.abc.MutableMapping, which breaks your imports. This does the import in a try/except block in a new `compat.py` file to avoid the bug.