### PR TITLE
Backward compatible Update to support Python 3.10 that Passes all unit tests

### DIFF
--- a/pyswagger/__init__.py
+++ b/pyswagger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.39-patched'
+__version__ = '0.8.39.0001'
 
 from .getter import Getter
 from .core import App, Security

--- a/pyswagger/__init__.py
+++ b/pyswagger/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.8.39'
+__version__ = '0.8.39-patched'
 
 from .getter import Getter
 from .core import App, Security

--- a/pyswagger/getter.py
+++ b/pyswagger/getter.py
@@ -45,7 +45,7 @@ class Getter(six.Iterator):
                 if obj.startswith('{'):
                     obj = json.loads(obj)
                 else:
-                    obj = yaml.load(obj)
+                    obj = yaml.safe_load(obj)
             except ValueError:
                 raise Exception('Unknown format startswith {0} ...'.format(obj[:10]))
 

--- a/pyswagger/io.py
+++ b/pyswagger/io.py
@@ -8,6 +8,14 @@ import io, codecs
 import collections
 import logging
 
+# Mapping and Mutable Mapping moved to collections.abc in Python 3.10
+try:
+    from collections import abc
+    collections.MutableMapping = abc.MutableMapping
+    collections.Mapping        = abc.Mapping
+except:
+    pass
+
 
 logger = logging.getLogger(__name__)
 

--- a/pyswagger/tests/contrib/client/test_flask.py
+++ b/pyswagger/tests/contrib/client/test_flask.py
@@ -196,8 +196,18 @@ class FlaskTestCase(unittest.TestCase):
         headers = [('X-TEST-HEADER', 'aaa'), ('X-TEST-HEADER', 'bbb')]
         resp = self.client.request(
             sapp.op['updatePet'](body=dict(id=1, name='Tom1')),
-            headers=headers
+            headers=headers,
+            opt={'join_headers': False}
         )
         self.assertEqual(received_headers.get_all('X-TEST-HEADER'), ['aaa, bbb'])
 
+ 
+        # with 'join_headers'
+        resp = self.client.request(
+            sapp.op['updatePet'](body=dict(id=1, name='Tom1')),
+            headers=headers,
+            opt={'join_headers': True}
+        )
+
+        self.assertEqual(received_headers.get_all('X-TEST-HEADER'), ['aaa,bbb'])
 

--- a/pyswagger/tests/contrib/client/test_flask.py
+++ b/pyswagger/tests/contrib/client/test_flask.py
@@ -198,14 +198,6 @@ class FlaskTestCase(unittest.TestCase):
             sapp.op['updatePet'](body=dict(id=1, name='Tom1')),
             headers=headers
         )
-        self.assertEqual(received_headers.get_all('X-TEST-HEADER'), ['bbb'])
-
-        # with 'join_headers'
-        resp = self.client.request(
-            sapp.op['updatePet'](body=dict(id=1, name='Tom1')),
-            headers=headers,
-            opt={'join_headers': True}
-        )
-        self.assertEqual(received_headers.get_all('X-TEST-HEADER'), ['aaa,bbb'])
+        self.assertEqual(received_headers.get_all('X-TEST-HEADER'), ['aaa, bbb'])
 
 

--- a/pyswagger/utils.py
+++ b/pyswagger/utils.py
@@ -9,7 +9,17 @@ import re
 import os
 import operator
 import functools
+
 import collections
+
+# Mapping and Mutable Mapping moved to collections.abc in Python 3.10
+try:
+    from collections import abc
+    collections.MutableMapping = abc.MutableMapping
+    collections.Mapping        = abc.Mapping
+except:
+    pass
+
 
 #TODO: accept varg
 def scope_compose(scope, name, sep=private.SCOPE_SEPARATOR):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
-six>=1.6.0
-pyaml>=15.03.1
+certifi>=2024.6.2
+charset-normalizer>=3.3.2
+idna>=3.7
+pyaml>=24.4.0
+PyYAML>=6.0.1
+requests>=2.32.3
+six>=1.16.0
+urllib3>=2.2.2
 validate_email>=1.3


### PR DESCRIPTION
This pull makes three minor changes to enable pyswagger to be used with Python 3.10 and the current versions of  PyYaml and Flask.

These changes should be backward compatible, and pass all unit tests.

1. Adapt to the move of `collections.Mapping` and `collections.MutableMapping` to `collections.abc.Mapping` and `collections.abc.MutableMapping`.
2. Use PyYAML's `yaml.safe_load` instead of `yaml.load`, which now requires an additional argument, and also prevent arbitrary code execution.
3. Update the flask tests to account for a change in how multiple values for the same header key are handled.